### PR TITLE
Make file paths relative to project root

### DIFF
--- a/Main/ClimateCalibration.r
+++ b/Main/ClimateCalibration.r
@@ -1,7 +1,8 @@
 #calibrate climate scenarios
 #read the data
- dir.climate.data<-"C:\\~Model Development\\TechChange-RDM\\ClimateDataCalibration\\"
- climate.data<-read.csv(paste(dir.climate.data,"AllGCMs.csv",sep=""))
+## Use project-relative path for climate calibration data
+dir.climate.data <- file.path(getwd(), "ClimateDataCalibration")
+climate.data <- read.csv(file.path(dir.climate.data, "AllGCMs.csv"))
 
 #PART1: CALIBRATION OF DELTA TEMP VS LOG CO2 FUNCTION
 climate.models<-unique(climate.data$Climate.Model)
@@ -32,18 +33,19 @@ delta.temp.disater<-7.5 #[degrees Celsius] increase in average global temperatur
    result$CO2.Disaster<-result$CO2.base*exp(delta.temp.disater/result$Beta.Delta.Temp)
    result$Delta.Temp.Disaster<-delta.temp.disater
 #print climate model parameters
-  write.csv(result, paste(dir.climate.data, "Climate_ScenariosTable1.csv", sep=""), row.names=FALSE)
+write.csv(result, file.path(dir.climate.data, "Climate_ScenariosTable1.csv"), row.names = FALSE)
 
 
 #PART2: CALIBRATION OF S EQUATION
 #read the data
- dir.climate.data<-"C:\\Users\\emolina\\Edmundo-RAND\\Projects\\Dissertation\\Model Development\\TechChange-RDM\\ClimateDataCalibration\\"
- climate.data<-read.csv(paste(dir.climate.data,"AllGCMs.csv",sep=""))
+## Reset path to the climate calibration data using the project directory
+dir.climate.data <- file.path(getwd(), "ClimateDataCalibration")
+climate.data <- read.csv(file.path(dir.climate.data, "AllGCMs.csv"))
 #The historical record across RCPs is the same, thus we aggregate the models at RCP level
  climate.data<-aggregate(climate.data[,"co2.ppm"],list(Climate.Model=climate.data$Climate.Model,Year=climate.data$Year),mean)
  colnames(climate.data)[ncol(climate.data)]<-"co2.ppm"
 #load initial scenario parameters
- climate.param.ini<-read.csv(paste(dir.climate.data,"Climate_ScenariosTable1.csv",sep=""))
+climate.param.ini <- read.csv(file.path(dir.climate.data, "Climate_ScenariosTable1.csv"))
  climate.param.ini<-climate.param.ini[,c("Climate.Model","CO2.Disaster")]
 #merge CO2 Disaster with raw data
   dim(climate.data)
@@ -58,7 +60,7 @@ delta.temp.disater<-7.5 #[degrees Celsius] increase in average global temperatur
   climate.models<-unique(climate.data$Climate.Model)
   length(climate.models)
 #load data of world consumption of fossil fuels
-  fossil.fuel<-read.csv(paste(dir.climate.data,"FossilFuelConsumption.csv",sep=""))
+fossil.fuel <- read.csv(file.path(dir.climate.data, "FossilFuelConsumption.csv"))
   fossil.fuel<-fossil.fuel[,c("Year","Fossil.Fuels.Consumption")] # Quadrillion Btu
 
 #loop across models
@@ -100,8 +102,8 @@ for (j in 2:length(climate.models))
   }
 
 #Create a table with parameters for all climate models
- climate.param.ini<-read.csv(paste(dir.climate.data,"Climate_ScenariosTable1.csv",sep=""))
+climate.param.ini <- read.csv(file.path(dir.climate.data, "Climate_ScenariosTable1.csv"))
  climate.param.ini<-climate.param.ini[,c("Climate.Model","Beta.Delta.Temp","CO2.base","CO2.Disaster","Delta.Temp.Disaster")]
 #merge
  climate.param<-merge(climate.param.ini,s.parameters,by="Climate.Model")
- write.csv(climate.param, paste(dir.climate.data, "Climate.csv", sep=""), row.names=FALSE)
+write.csv(climate.param, file.path(dir.climate.data, "Climate.csv"), row.names = FALSE)

--- a/Main/Main_vFrontiers.r.r
+++ b/Main/Main_vFrontiers.r.r
@@ -1,41 +1,42 @@
 #cloud
- root<-"C:\\~TechChange-RDM\\"
+## Set project root dynamically based on the current working directory
+root <- file.path(getwd(), "")
  Number.Cores<-32
 
 ## =================================================================================================================================================
 ## This section creates the Experimental Design Based on Input Tables
 ## =================================================================================================================================================
-  dir.exp.inputs<-paste(root,"RDM Inputs\\",sep="")
+  dir.exp.inputs <- file.path(root, "RDM Inputs")
   Limits.File<-"Limits.csv"
   Policies.File<-"Policies.csv"
   Climate.File<-"Climate.csv"
   sample.size<-300
   Policy.Switch<-TRUE
   Climate.Switch<-TRUE
-  source(paste(dir.exp.inputs,"create_experiment_function.r",sep=""))
+  source(file.path(dir.exp.inputs, "create_experiment_function.r"))
   Exp.design<-exp.design.table(dir.exp.inputs,Limits.File,sample.size,Policies.File,Policy.Switch,Climate.File,Climate.Switch)
-  write.csv(Exp.design, paste(dir.exp.inputs, "Exp.design.csv", sep=""), row.names=FALSE)
+  write.csv(Exp.design, file.path(dir.exp.inputs, "Exp.design.csv"), row.names = FALSE)
 
 ## ==================================================================================================================================================
 ## This section runs the model across the experimental design and prints an output file for each run
 ## ==================================================================================================================================================
 #Source Model
-  dir.model<-paste(root,"TechChange Model\\",sep="")
+  dir.model <- file.path(root, "TechChange Model")
   model.version<-"InternationalGreenTechChangeModel_10_22_2015.r"
-  source(paste(dir.model,model.version,sep=""))
+  source(file.path(dir.model, model.version))
 #Source Experimental Design
-  dir.exp<-paste(root,"RDM Inputs\\",sep="")
+  dir.exp <- file.path(root, "RDM Inputs")
   experiment.version<-"Exp.design.csv"
-  Exp.design<-read.csv(paste(dir.exp,experiment.version,sep=""))
+  Exp.design <- read.csv(file.path(dir.exp, experiment.version))
 #Define directory to print output files
-  dir.harness<-paste(root,"RDM Harness\\",sep="")
+  dir.harness <- file.path(root, "RDM Harness")
 #Clean output folder
-  do.call(file.remove,list(paste(dir.harness,list.files(dir.harness, pattern="*.csv", full.names=FALSE),sep="")))
+  do.call(file.remove, list(file.path(dir.harness, list.files(dir.harness, pattern = "*.csv", full.names = FALSE))))
 #Set up parallel environment
 #Run Model in Parallel
-  library(snow,lib=paste(root,"Rlibraries\\",sep=""))
-  library(deSolve,lib=paste(root,"Rlibraries\\",sep=""))
-  library(optimx,lib=paste(root,"Rlibraries\\",sep=""))
+  library(snow, lib = file.path(root, "Rlibraries"))
+  library(deSolve, lib = file.path(root, "Rlibraries"))
+  library(optimx, lib = file.path(root, "Rlibraries"))
   nCore<-Number.Cores
   cl <- makeSOCKcluster(names = rep('localhost',nCore))
   global.elements<-list("Exp.design","TechChangeMod","dir.harness","dede","lagderiv","lagvalue","optimx") # dede, lagderiv are functions od deSolve
@@ -158,23 +159,25 @@ if (x['policy.name']=="FWA")
 ## =====================================================================================================
   Number.Cores<-4
  #Define directory parameters
-  dir.inputs<-paste(root,"RDM Inputs\\",sep="")
-  dir.harness<-paste(root,"RDM Harness\\",sep="")
-  dir.output<-paste(root,"RDM Outputs\\",sep="")
+  dir.inputs <- file.path(root, "RDM Inputs")
+  dir.harness <- file.path(root, "RDM Harness")
+  dir.output <- file.path(root, "RDM Outputs")
  #load needed libraries
-  library(reshape2,lib= paste(root,"Rlibraries\\",sep=""))
-  library(data.table,lib=paste(root,"Rlibraries\\",sep=""))
-  library(snow,lib=paste(root,"Rlibraries\\",sep=""))
+  library(reshape2, lib = file.path(root, "Rlibraries"))
+  library(data.table, lib = file.path(root, "Rlibraries"))
+  library(snow, lib = file.path(root, "Rlibraries"))
 #create vector with file names
-  filenames <- list.files(dir.harness, pattern="*.csv", full.names=FALSE)
+  filenames <- list.files(dir.harness, pattern="*.csv", full.names = FALSE)
 #source function to process harnessed output data
-  source(paste(dir.inputs,"harness_processing.r",sep=""))
+  source(file.path(dir.inputs, "harness_processing.r"))
 #run post-processing in parallel
   nCore<-Number.Cores
   cl <- makeSOCKcluster(names = rep('localhost',nCore))
   global.elements<-list("dir.harness","process.prim.data","data.table")
   clusterExport(cl,global.elements,envir=environment())
-  prim.data <- parLapply(cl,filenames, function(x){data.table(process.prim.data(x,dir.harness))} )
+  prim.data <- parLapply(cl, filenames, function(x) {
+    data.table(process.prim.data(x, dir.harness))
+  })
   stopCluster(cl)
   prim.data<-rbindlist(prim.data)
 #merge data with experimental design
@@ -194,28 +197,28 @@ if (x['policy.name']=="FWA")
   prim.data$Z.Relative.Nu<-scale(prim.data$Z.Relative.Nu, center=TRUE, scale=TRUE)
   prim.data$Z.epsilon<-scale(prim.data$epsilon, center=TRUE, scale=TRUE)
 
-  #write.csv(prim.data, paste(dir.output, "prim.data_7_06_2015.csv", sep=""), row.names=FALSE)
-  write.csv(prim.data, paste(dir.output, "prim.data_extras_seminar.csv", sep=""), row.names=FALSE)
+  #write.csv(prim.data, file.path(dir.output, "prim.data_7_06_2015.csv"), row.names = FALSE)
+  write.csv(prim.data, file.path(dir.output, "prim.data_extras_seminar.csv"), row.names = FALSE)
 
 ## =====================================================================================================
 ## This section reads the output of simulations and reshapes it into time series split by region,
 ## =====================================================================================================
 Number.Cores<-18
 #Define directory parameters
- dir.inputs<-paste(root,"RDM Inputs\\",sep="")
- dir.harness<-paste(root,"RDM Harness\\",sep="")
- dir.output<-paste(root,"RDM Outputs\\",sep="")
+ dir.inputs <- file.path(root, "RDM Inputs")
+ dir.harness <- file.path(root, "RDM Harness")
+ dir.output <- file.path(root, "RDM Outputs")
 
 #crate vector with file names
  experiment.version<-"Exp.design.csv"
  #experiment.version<-"Exp.design_with_control_runs.csv"
  #experiment.version<-"Exp.design_defense_seminar_extras.csv"
- filenames <- list.files(dir.harness, pattern="*.csv", full.names=FALSE)
+ filenames <- list.files(dir.harness, pattern="*.csv", full.names = FALSE)
 #source function to process harnessed output data
- source(paste(dir.inputs,"harness_processing.r",sep=""))
+  source(file.path(dir.inputs, "harness_processing.r"))
 #run post-processing in parallel
-  library(data.table,lib=paste(root,"Rlibraries\\",sep=""))
-  library(snow,lib=paste(root,"Rlibraries\\",sep=""))
+  library(data.table, lib = file.path(root, "Rlibraries"))
+  library(snow, lib = file.path(root, "Rlibraries"))
   nCore<-Number.Cores
   cl <- makeSOCKcluster(names = rep('localhost',nCore))
   global.elements<-list("dir.inputs","experiment.version","dir.harness","process.harness.data")
@@ -224,4 +227,4 @@ Number.Cores<-18
   stopCluster(cl)
   modelruns<-rbindlist(modelruns)
 #print time series for model
-  write.csv(modelruns, paste(dir.output, "model.runs_7_09_2015.csv", sep=""), row.names=FALSE)
+  write.csv(modelruns, file.path(dir.output, "model.runs_7_09_2015.csv"), row.names = FALSE)

--- a/Main/harness_processing.r
+++ b/Main/harness_processing.r
@@ -6,9 +6,9 @@ process.harness.data<-function(filename,dir.inputs,experiment.version,dir.harnes
  library(reshape2)
  library(data.table)
 #load experimental design
-  Exp.design<-read.csv(paste(dir.inputs,experiment.version,sep=""))
+  Exp.design <- read.csv(file.path(dir.inputs, experiment.version))
 #load harness data
-  harness.data<-data.table(read.csv(paste(dir.harness,filename,sep="")))
+  harness.data <- data.table(read.csv(file.path(dir.harness, filename)))
 #convert integer values in Exp.design into numeric
   integers<-names(subset(sapply(Exp.design,is.integer),sapply(Exp.design,is.integer)==TRUE))
   Exp.design[,integers]<- lapply(Exp.design[,integers], as.numeric)
@@ -94,7 +94,7 @@ return(harness.data)
 ## This functions reshapes output of model
 ## =======================================================================
 process.prim.data<-function(filename,dir.harness){
-  harness.data<-read.csv(paste(dir.harness,filename,sep=""))
+  harness.data <- read.csv(file.path(dir.harness, filename))
   #First obtain the policy vector
    policy.elements<-c("Policy.Start.Time","Policy.Duration",
                      "ce.tax_N","RD.subsidy_N","RD.subsidy.GF_N","Tec.subsidy_N","Tec.subsidy.GF_N",
@@ -132,7 +132,7 @@ process.prim.data<-function(filename,dir.harness){
 merge.exp.design<-function(dir.inputs,experiment.version,data)
 {
  #load experimental design
-  Exp.design<-read.csv(paste(dir.inputs,experiment.version,sep=""))
+  Exp.design <- read.csv(file.path(dir.inputs, experiment.version))
 #convert integer values in Exp.design into numeric
   integers<-names(subset(sapply(Exp.design,is.integer),sapply(Exp.design,is.integer)==TRUE))
   Exp.design[,integers]<- lapply(Exp.design[,integers], as.numeric)

--- a/Main/main_calib.r
+++ b/Main/main_calib.r
@@ -1,20 +1,21 @@
 #define vector for output
- root<-"C:\\~Model Development\\TechChange-RDM\\"
+## Set project root dynamically based on the current working directory
+root <- file.path(getwd(), "")
 
 #this script has been created to find the optimal value of policies for a future id,
-  library(deSolve,lib=paste(root,"Rlibraries\\",sep=""))
-  library(optimx,lib=paste(root,"Rlibraries\\",sep=""))
-  dir.harness<-paste(root,"RDM Harness\\",sep="")
+  library(deSolve, lib = file.path(root, "Rlibraries"))
+  library(optimx, lib = file.path(root, "Rlibraries"))
+  dir.harness <- file.path(root, "RDM Harness")
 #Source Experimental Design
-  dir.exp<-paste(root,"RDM Inputs\\",sep="")
+  dir.exp <- file.path(root, "RDM Inputs")
   experiment.version<-"Exp.design_calib.csv"
-  Exp.design<-read.csv(paste(dir.exp,experiment.version,sep=""))
+  Exp.design <- read.csv(file.path(dir.exp, experiment.version))
 #run the model once
 
 #Source Model
-  dir.model<-paste(root,"TechChange Model\\",sep="")
+  dir.model <- file.path(root, "TechChange Model")
   model.version<-"InternationalGreenTechChangeModel_9_19_2015_calib.r"
-  source(paste(dir.model,model.version,sep=""))
+  source(file.path(dir.model, model.version))
 
 target.run<-1
 params<-c(
@@ -57,21 +58,21 @@ TechChangeMod(c(0.03,1.0,0.02,0.01,0.05,1.0,0.02,0.5),params)
 ## This section reads the output of simulations and reshapes it into time series split by region,
 ## =====================================================================================================
 #Define directory parameters
- dir.inputs<-paste(root,"RDM Inputs\\",sep="")
- dir.harness<-paste(root,"RDM Harness\\",sep="")
- dir.output<-paste(root,"RDM Outputs\\",sep="")
+ dir.inputs <- file.path(root, "RDM Inputs")
+ dir.harness <- file.path(root, "RDM Harness")
+ dir.output <- file.path(root, "RDM Outputs")
 
 #create vector with file names
  experiment.version<-"Exp.design_calib.csv"
- filenames <- list.files(dir.harness, pattern="*.csv", full.names=FALSE)
+ filenames <- list.files(dir.harness, pattern = "*.csv", full.names = FALSE)
 #source function to process harnessed output data
- source(paste(dir.inputs,"harness_processing.r",sep=""))
+ source(file.path(dir.inputs, "harness_processing.r"))
 #run post-processing in parallel
-  library(data.table,lib=paste(root,"Rlibraries\\",sep=""))
-  library(snow,lib=paste(root,"Rlibraries\\",sep=""))
+  library(data.table, lib = file.path(root, "Rlibraries"))
+  library(snow, lib = file.path(root, "Rlibraries"))
   modelruns<-process.harness.data(filenames[1],dir.inputs,experiment.version,dir.harness)
 #print time series for model
-  write.csv(modelruns, paste(root,"ParameterCalibration\\", "model.runs_calib.csv", sep=""), row.names=FALSE)
+  write.csv(modelruns, file.path(root, "ParameterCalibration", "model.runs_calib.csv"), row.names = FALSE)
 
 
 ## =====================================================================================================
@@ -79,13 +80,13 @@ TechChangeMod(c(0.03,1.0,0.02,0.01,0.05,1.0,0.02,0.5),params)
 ## =====================================================================================================
 
 #this script puts together the data for the historic calibration
-  dir.output<-paste(root,"RDM Outputs\\",sep="")
-  dir.historic<-paste(root,"ParameterCalibration\\",sep="")
+  dir.output <- file.path(root, "RDM Outputs")
+  dir.historic <- file.path(root, "ParameterCalibration")
 
 #read historic data
-  historic<-read.csv(paste(dir.historic,"historic_energy_both_regions _v1.csv",sep=""))
+  historic <- read.csv(file.path(dir.historic, "historic_energy_both_regions _v1.csv"))
 #read simulated data
-  data<-read.csv(paste(dir.historic,"model.runs_calib.csv",sep=""))
+  data <- read.csv(file.path(dir.historic, "model.runs_calib.csv"))
   data<-data[,c("Run.ID","time","Region","Y","Yce","Yre","Ace","Are","L","policy.name",
                 "epsilon","rho","alfa","Eta.re","Eta.ce","Gamma.re","Gamma.ce","Nu.re","Nu.ce",
    				"k.re","k.ce","labor.growth","size.factor")]
@@ -97,4 +98,4 @@ TechChangeMod(c(0.03,1.0,0.02,0.01,0.05,1.0,0.02,0.5),params)
  data.historic$Region<-gsub("S","NONOECD",data.historic$Region)
  data.historic$Run.ID<-data.historic$Run.ID+1
  data<-rbind(data,data.historic)
-  write.csv(data, paste(dir.output, "historic_calib.csv", sep=""), row.names=FALSE)
+   write.csv(data, file.path(dir.output, "historic_calib.csv"), row.names = FALSE)

--- a/Main/sdprim_vFrontiers.r.r
+++ b/Main/sdprim_vFrontiers.r.r
@@ -2,19 +2,20 @@
 ## This section runs PRIM accross the experimental results data set
 ## =====================================================================================================
 #cloud
- #root<-"C:\\~TechChange-RDM\\"
- #Number.Cores<-30
+# Set project root dynamically based on the current working directory
+root <- file.path(getwd(), "")
+#Number.Cores<-30
 
 #load libraries
- library(sdtoolkit,lib=paste(root,"Rlibraries\\",sep=""))
- library(data.table,lib=paste(root,"Rlibraries\\",sep=""))
+library(sdtoolkit, lib = file.path(root, "Rlibraries"))
+library(data.table, lib = file.path(root, "Rlibraries"))
 
 #Set parameters
- dir.prim<-paste(root,"RDM Outputs\\",sep="")
+dir.prim <- file.path(root, "RDM Outputs")
  prim.file<-"prim.data_7_06_2015.csv"
 
 #load prim data
- prim.data<-data.table(read.csv(paste(dir.prim,prim.file,sep="")) )
+prim.data <- data.table(read.csv(file.path(dir.prim, prim.file)))
 
 #compute relative variables to be used in prim as inputs
   prim.data[,Relative.A_N:=Are.N/Ace.N]
@@ -65,11 +66,11 @@
                                     by = list( policy.name)])
 
 #Filter data for analysis
- dir.inputs<-paste(root,"RDM Inputs\\",sep="")
+dir.inputs <- file.path(root, "RDM Inputs")
  Policies.File<-"Policies.csv"
  Climate.File<-"Climate.csv"
- Policies<-read.csv(paste(dir.inputs,Policies.File,sep=""))
- Climate<-read.csv(paste(dir.inputs,Climate.File,sep=""))
+Policies <- read.csv(file.path(dir.inputs, Policies.File))
+Climate <- read.csv(file.path(dir.inputs, Climate.File))
 
 #Select prim inputs,
  inputs.vector<-c("Relative.A_N",
@@ -185,7 +186,7 @@ sdprim(prim.inputs,prim$objective, thresh=0.5, threshtype=">",peel_crit = 2,repr
 
 
 #using PCA
- library(psych,lib=paste(root,"Rlibraries\\",sep=""))
+library(psych, lib = file.path(root, "Rlibraries"))
  fit <- principal(prim.inputs, nfactors=4, rotate="varimax",scores=TRUE)
  PCA.factors<-data.frame(fit$scores)
 
@@ -671,5 +672,5 @@ uncertainties<-c("epsilon","rho","Climate.Model","Beta.Delta.Temp")
   robust.mapping<-rbind(robust.mapping.stabilization,robust.mapping.temperature.rise,bad.futures)
   dim(robust.mapping)
 #write final file
-   dir.prim<-paste(root,"RDM Outputs\\",sep="")
-   write.csv(robust.mapping, paste(dir.prim, "robust_mapping.csv", sep=""), row.names=FALSE)
+  dir.prim <- file.path(root, "RDM Outputs")
+  write.csv(robust.mapping, file.path(dir.prim, "robust_mapping.csv"), row.names = FALSE)


### PR DESCRIPTION
## Summary
- use `getwd()` with `file.path` for project root
- build directories using `file.path`
- update harness processing scripts to load data with `file.path`
- ensure climate calibration uses project-relative data folder

## Testing
- `Rscript -e "cat('R session OK\n')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c820edba4833187a184c6d22e6bf7